### PR TITLE
Load package even without libveda

### DIFF
--- a/src/veda/VEDA.jl
+++ b/src/veda/VEDA.jl
@@ -67,6 +67,7 @@ module VEDA
     const libcache = Base.WeakKeyDict{VEContext, VEModule}()
 
     function __init__()
+        isempty(API.libveda) && return
         # TODO: Do a lazy init
         API.vedaInit(0)
         ctx = VEContext(0)


### PR DESCRIPTION
This is similar to how CUDA.jl and AMDGPU.jl work, and makes it possible for other packages in the ecosystem to depend on VectorEngine.jl directly without harming users who don't have the right software or hardware setup.